### PR TITLE
add name extraction to getRepos

### DIFF
--- a/src/api-sdk/github/mapping.ts
+++ b/src/api-sdk/github/mapping.ts
@@ -2,6 +2,7 @@ import { GitHubMembers, GitHubRepos, GitHubTeams, GitHubMembersPerTeam, GitHubRe
 
 export const reposMapping = (body: any[]): GitHubRepos[] => {
     return body.map((obj) => ({
+        name: obj.name,
         description: obj.description,
         full_name: obj.full_name,
         visibility: obj.visibility,

--- a/src/api-sdk/github/type.ts
+++ b/src/api-sdk/github/type.ts
@@ -1,4 +1,5 @@
 export interface GitHubRepos {
+    name: string;
     description: string;
     full_name: string;
     visibility: string;

--- a/test/mock/data.mock.ts
+++ b/test/mock/data.mock.ts
@@ -8,6 +8,7 @@ export const MOCK_HEADERS: ApiOptions = {
 
 export const MOCK_REPOS = [
     {
+        name: "repo1",
         archived: false,
         created_at: '2015-12-10T11:48:11Z',
         description: 'Best repo 1',
@@ -17,6 +18,7 @@ export const MOCK_REPOS = [
         visibility: 'public'
     },
     {
+        name: "repo2",
         archived: false,
         created_at: '2018-12-10T11:48:11Z',
         description: 'Best repo 2',
@@ -29,6 +31,7 @@ export const MOCK_REPOS = [
 
 export const MOCK_UNMAPPED_ENTREE_REPO = [
     {
+        name: "repo1",
         archived: false,
         created_at: '2015-12-10T11:48:11Z',
         description: 'Best repo 1',
@@ -39,6 +42,7 @@ export const MOCK_UNMAPPED_ENTREE_REPO = [
         test: 'test'
     },
     {
+        name: "repo2",
         archived: false,
         created_at: '2018-12-10T11:48:11Z',
         description: 'Best repo 2',


### PR DESCRIPTION
### JIRA link

Resolves [NTRNL-266](https://technologyprogramme.atlassian.net/browse/NTRNL-266)

### Description

- Added name extraction for the method getRepos, old implementation was only extracting the full_name

### Work checklist

- [x] Tests added where applicable
- [x] No vulnerability added