### PR TITLE
Update axios dependency to the lates version and bump module version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@co-digital/api-sdk",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@co-digital/api-sdk",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.6.0"
+        "axios": "^1.7.4"
       },
       "devDependencies": {
         "@types/node": "^20.8.7",
@@ -1796,11 +1796,11 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@co-digital/api-sdk",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "An API SDK for Node.JS applications in CO Digital.",
   "homepage": "https://github.com/cabinetoffice/node-api-sdk#README.md",
   "main": "./lib/index.js",
@@ -36,7 +36,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "axios": "^1.6.0"
+    "axios": "^1.7.4"
   },
   "files": [
     "./lib/**/*"


### PR DESCRIPTION
### JIRA link

Resolves [NTRNL-549](https://technologyprogramme.atlassian.net/browse/NTRNL-549)

### Description

- Bump axios dependency to lates version **1.7.4**
- Bump **@co-digital/api-sdk** from 1.0.6 to 1.0.7
