### PR TITLE
Add post and get generic call on Node SDK Api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@co-digital/api-sdk",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@co-digital/api-sdk",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@co-digital/api-sdk",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "An API SDK for Node.JS applications in CO Digital.",
   "homepage": "https://github.com/cabinetoffice/node-api-sdk#README.md",
   "main": "./lib/index.js",

--- a/src/api-sdk/github/github.ts
+++ b/src/api-sdk/github/github.ts
@@ -66,6 +66,18 @@ export class Github {
         return this.responseHandler<GitHubCollaboratorsPerRepo[]>(response, collaboratorsPerRepoMapping);
     }
 
+    // generic get and post functions
+
+    public async getData(url: string): Promise<ApiResponse<any> | ApiErrorResponse> {
+        const response = await this.request.httpGet(url);
+        return this.responseHandler<any>(response);
+    }
+
+    public async postData(url: string, body: any): Promise<ApiResponse<any> | ApiErrorResponse> {
+        const response = await this.request.httpPost(url, JSON.stringify(body));
+        return this.responseHandler<any>(response);
+    }
+
     private responseHandler<T>(
         response: any,
         responseMap?: (body: any) => T

--- a/test/mock/data.mock.ts
+++ b/test/mock/data.mock.ts
@@ -8,7 +8,7 @@ export const MOCK_HEADERS: ApiOptions = {
 
 export const MOCK_REPOS = [
     {
-        name: "repo1",
+        name: 'repo1',
         archived: false,
         created_at: '2015-12-10T11:48:11Z',
         description: 'Best repo 1',
@@ -18,7 +18,7 @@ export const MOCK_REPOS = [
         visibility: 'public'
     },
     {
-        name: "repo2",
+        name: 'repo2',
         archived: false,
         created_at: '2018-12-10T11:48:11Z',
         description: 'Best repo 2',
@@ -31,7 +31,7 @@ export const MOCK_REPOS = [
 
 export const MOCK_UNMAPPED_RESPONSE_REPO = [
     {
-        name: "repo1",
+        name: 'repo1',
         archived: false,
         created_at: '2015-12-10T11:48:11Z',
         description: 'Best repo 1',
@@ -42,7 +42,7 @@ export const MOCK_UNMAPPED_RESPONSE_REPO = [
         test: 'test'
     },
     {
-        name: "repo2",
+        name: 'repo2',
         archived: false,
         created_at: '2018-12-10T11:48:11Z',
         description: 'Best repo 2',
@@ -80,7 +80,7 @@ export const MOCK_FULL_RESPONSE_MEMBERS = [ ...MOCK_MEMBERS ];
 
 export const MOCK_MEMBER_FETCH_RESPONSE = {
     httpStatusCode: 200,
-    resource: MOCK_MEMBERS.map(({ repos_url, ...rest }) => rest)
+    resource: MOCK_MEMBERS.map(({ repos_url: _repos_url, ...rest }) => rest)
 };
 
 export const MOCK_TEAMS = [
@@ -104,7 +104,7 @@ export const MOCK_TEAMS = [
 
 export const MOCK_TEAM_FETCH_RESPONSE = {
     httpStatusCode: 200,
-    resource: MOCK_TEAMS.map(({ members_url, repositories_url, ...rest }) => rest)
+    resource: MOCK_TEAMS.map(({ members_url: _members_url, repositories_url: _repositories_url, ...rest }) => rest)
 };
 
 export const MOCK_MEMBERS_PER_TEAM = [
@@ -150,22 +150,22 @@ export const MOCK_COLLABORATORS_PER_REPO = [
 
 export const MOCK_COLLABORATORS_PER_REPO_RESPONSE = {
     httpStatusCode: 200,
-    resource: MOCK_COLLABORATORS_PER_REPO.map(({ other, ...rest }) => rest)
+    resource: MOCK_COLLABORATORS_PER_REPO.map(({ other: _other, ...rest }) => rest)
 };
 
 export const MOCK_ISSUE_BODY = {
-    title: "Add member to the team",
-    body: "Add member Bob to the team Alice.",
-    assignees: ["IDC TEAM"],
-    labels: ["GIT"]
+    title: 'Add member to the team',
+    body: 'Add member Bob to the team Alice.',
+    assignees: ['IDC TEAM'],
+    labels: ['GIT']
 };
 
 export const MOCK_ISSUE_RESPONSE = {
     id: 1,
     number: 1347,
-    state: "open",
-    title: "Add member to the team",
-    body: "Add member Bob to the team Alice."
+    state: 'open',
+    title: 'Add member to the team',
+    body: 'Add member Bob to the team Alice.'
 };
 
 export const MOCK_ERROR = {
@@ -177,9 +177,23 @@ export const MOCK_ERROR_RESPONSE = {
     errors: [MOCK_ERROR]
 };
 
-export const MOCK_403_ERROR_MSG = { "message": "Must have admin rights to Repository." };
+export const MOCK_403_ERROR_MSG = { 'message': 'Must have admin rights to Repository.' };
 
 export const MOCK_403_ERROR_RESPONSE = {
     httpStatusCode: 403,
     errors: [MOCK_403_ERROR_MSG]
+};
+
+export const MOCK_GET = { data: 'test data' };
+
+export const MOCK_GET_RESPONSE = {
+    httpStatusCode: 200,
+    resource: MOCK_GET
+};
+
+export const MOCK_POST = { success: true };
+
+export const MOCK_POST_RESPONSE = {
+    httpStatusCode: 200,
+    resource: MOCK_POST
 };

--- a/test/unit/api-sdk/github/github.spec.ts
+++ b/test/unit/api-sdk/github/github.spec.ts
@@ -23,7 +23,11 @@ import {
     MOCK_FULL_RESPONSE_REPO,
     MOCK_FULL_RESPONSE_MEMBERS,
     MOCK_ISSUE_RESPONSE,
-    MOCK_ISSUE_BODY
+    MOCK_ISSUE_BODY,
+    MOCK_GET,
+    MOCK_GET_RESPONSE,
+    MOCK_POST,
+    MOCK_POST_RESPONSE
 } from '../../../mock/data.mock';
 import { HttpResponse } from '../../../../src/http-request/type';
 
@@ -135,6 +139,28 @@ describe('Github sdk module test suites', () => {
         const url = 'https://api.github.com/repos/organizations/repo/collaborators';
         const result = await github.getCollaboratorsPerRepo(url);
         expect(result).toEqual(MOCK_COLLABORATORS_PER_REPO_RESPONSE);
+    });
+
+    test('should return get data ', async () => {
+        httpRequestMock.httpGet.mockResolvedValue(createMockHttpResponse(MOCK_GET));
+
+        const url = 'https://api.github.com/test/get';
+        const result = await github.getData(url);
+
+        expect(httpRequestMock.httpGet).toHaveBeenCalledWith(url);
+        expect(result).toEqual(MOCK_GET_RESPONSE);
+    });
+
+    test('should post data successfully', async () => {
+        httpRequestMock.httpPost.mockResolvedValue(createMockHttpResponse(MOCK_POST));
+
+        const url = 'https://api.github.com/test/post';
+        const body = { key: 'value' };
+
+        const result = await github.postData(url, body);
+
+        expect(httpRequestMock.httpPost).toHaveBeenCalledWith(url, JSON.stringify(body));
+        expect(result).toEqual(MOCK_POST_RESPONSE);
     });
 
     test('Should return an object with an error property', async () => {


### PR DESCRIPTION
### JIRA link

Resolves [IDP-440](https://technologyprogramme.atlassian.net/browse/IDP-440)

### Description

- Add get and post generic API calls. 
- Fix linting issues in mocks which break our ESlint rules

For more context on the possibilities with these changes please see the [card](https://technologyprogramme.atlassian.net/browse/IDP-440).

### Work checklist

- [x] Tests added where applicable
- [x] No vulnerability added